### PR TITLE
Remove 'params', make the nsds5replicabindmethod parametric

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,9 @@ dirsrv_tls_certificate_trusted: true
 dirsrv_serverid: default
 dirsrv_suffix: dc=example,dc=local
 
+# SIMPLE, PLAIN, SASL. 
+dirsrv_replica_bind_method: 'PLAIN'
+
 #####################
 # Supplier settings #
 #####################
@@ -18,7 +21,7 @@ dirsrv_supplier_replica_id: 1  # For suppliers: 1 to 65534
 # dirsrv_replication_user_password_remote: even-more-secret
 dirsrv_changelog_max_age: "10d"
 
-# By default nothing is excluded, but those are used in the exmaples. Probably there's a good reason for why they are excluded.
+# By default nothing is excluded, but those are used in the examples. Probably there's a good reason for why they are excluded.
 dirsrv_replica_attributes_list: "(objectclass=*) $ EXCLUDE authorityRevocationList accountUnlockTime memberof"
 dirsrv_replica_attributes_list_total: "(objectclass=*) $ EXCLUDE accountUnlockTime"
 

--- a/tasks/configure_changelog.yml
+++ b/tasks/configure_changelog.yml
@@ -1,7 +1,11 @@
 ---
 - name: Create changelog configuration entry
   ldap_entry:
-    params: "{{ dirsrv_ldap_auth }}"
+    server_uri: "{{ dirsrv_server_uri }}"
+    validate_certs: "{{ dirsrv_tls_certificate_trusted }}"
+    start_tls: "{{ dirsrv_starttls_early }}"
+    bind_dn: "{{ dirsrv_rootdn }}"
+    bind_pw: "{{ dirsrv_rootdn_password }}"
     dn: "cn=changelog5,cn=config"
     objectClass:
       - top
@@ -15,7 +19,11 @@
 
 - name: Configure changelog
   ldap_attr:
-    params: "{{ dirsrv_ldap_auth }}"
+    server_uri: "{{ dirsrv_server_uri }}"
+    validate_certs: "{{ dirsrv_tls_certificate_trusted }}"
+    start_tls: "{{ dirsrv_starttls_early }}"
+    bind_dn: "{{ dirsrv_rootdn }}"
+    bind_pw: "{{ dirsrv_rootdn_password }}"
     dn: "cn=changelog5,cn=config"
     name: "{{ item.name }}"
     values: "{{ item.value }}"

--- a/tasks/configure_consumer.yml
+++ b/tasks/configure_consumer.yml
@@ -1,7 +1,11 @@
 ---
 - name: Create Consumer Replica Entry
   ldap_entry:
-    params: "{{ dirsrv_ldap_auth }}"
+    server_uri: "{{ dirsrv_server_uri }}"
+    validate_certs: "{{ dirsrv_tls_certificate_trusted }}"
+    start_tls: "{{ dirsrv_starttls_early }}"
+    bind_dn: "{{ dirsrv_rootdn }}"
+    bind_pw: "{{ dirsrv_rootdn_password }}"
     dn: "cn=replica,cn=\"{{ dirsrv_suffix }}\",cn=mapping tree,cn=config"
     objectClass:
       - top
@@ -17,7 +21,11 @@
 
 - name: Configure Consumer Replica Entry
   ldap_attr:
-    params: "{{ dirsrv_ldap_auth }}"
+    server_uri: "{{ dirsrv_server_uri }}"
+    validate_certs: "{{ dirsrv_tls_certificate_trusted }}"
+    start_tls: "{{ dirsrv_starttls_early }}"
+    bind_dn: "{{ dirsrv_rootdn }}"
+    bind_pw: "{{ dirsrv_rootdn_password }}"
     dn: "cn=replica,cn=\"{{ dirsrv_suffix }}\",cn=mapping tree,cn=config"
     name: "{{ item.name }}"
     values: "{{ item.value }}"
@@ -29,7 +37,11 @@
 
 - name: Configure referral
   ldap_attr:
-    params: "{{ dirsrv_ldap_auth }}"
+    server_uri: "{{ dirsrv_server_uri }}"
+    validate_certs: "{{ dirsrv_tls_certificate_trusted }}"
+    start_tls: "{{ dirsrv_starttls_early }}"
+    bind_dn: "{{ dirsrv_rootdn }}"
+    bind_pw: "{{ dirsrv_rootdn_password }}"
     dn: "cn=\"{{ dirsrv_suffix }}\",cn=mapping tree,cn=config"
     name: "{{ item.name }}"
     values: "{{ item.value }}"

--- a/tasks/configure_replication_agreement.yml
+++ b/tasks/configure_replication_agreement.yml
@@ -11,7 +11,11 @@
 # Add only to supplier, one for each consumer
 - name: "Add replication agreement with {{ dirsrv_consumer_uri | urlsplit('netloc') }} on supplier"
   ldap_entry:
-    params: "{{ dirsrv_ldap_auth }}"
+    server_uri: "{{ dirsrv_server_uri }}"
+    validate_certs: "{{ dirsrv_tls_certificate_trusted }}"
+    start_tls: "{{ dirsrv_starttls_early }}"
+    bind_dn: "{{ dirsrv_rootdn }}"
+    bind_pw: "{{ dirsrv_rootdn_password }}"
     dn: "cn={{ dirsrv_agreement_cn }},cn=replica,cn=\"{{ dirsrv_suffix  }}\",cn=mapping tree,cn=config"
     objectClass:
       - top
@@ -35,7 +39,11 @@
 
 - name: Configure replication agreement on supplier
   ldap_attr:
-    params: "{{ dirsrv_ldap_auth }}"
+    server_uri: "{{ dirsrv_server_uri }}"
+    validate_certs: "{{ dirsrv_tls_certificate_trusted }}"
+    start_tls: "{{ dirsrv_starttls_early }}"
+    bind_dn: "{{ dirsrv_rootdn }}"
+    bind_pw: "{{ dirsrv_rootdn_password }}"
     dn: "cn={{ dirsrv_agreement_cn }},cn=replica,cn=\"{{ dirsrv_suffix  }}\",cn=mapping tree,cn=config"
     name: "{{ item.name }}"
     values: "{{ item.value }}"
@@ -53,7 +61,11 @@
 # The downside is that if password actually changes, you'll see that nothing has changed according to Ansible, but it did work.
 - name: Configure password on replication agreement on supplier
   ldap_attr:
-    params: "{{ dirsrv_ldap_auth }}"
+    server_uri: "{{ dirsrv_server_uri }}"
+    validate_certs: "{{ dirsrv_tls_certificate_trusted }}"
+    start_tls: "{{ dirsrv_starttls_early }}"
+    bind_dn: "{{ dirsrv_rootdn }}"
+    bind_pw: "{{ dirsrv_rootdn_password }}"
     dn: "cn={{ dirsrv_agreement_cn }},cn=replica,cn=\"{{ dirsrv_suffix }}\",cn=mapping tree,cn=config"
     name: "nsds5ReplicaCredentials"
     values: "{{ dirsrv_replication_user_password_remote | default(dirsrv_replication_user_password) }}"

--- a/tasks/configure_replication_agreement.yml
+++ b/tasks/configure_replication_agreement.yml
@@ -29,7 +29,7 @@
       nsds5replicaport: "{{ '389' if not dirsrv_consumer_uri|urlsplit('port') else dirsrv_consumer_uri|urlsplit('port') }}"
       nsds5ReplicaBindDN: "cn={{ dirsrv_replication_user_remote | default(dirsrv_replication_user) }},cn=config"
       nsds5ReplicaCredentials: "{{ dirsrv_replication_user_password_remote | default(dirsrv_replication_user_password) }}"
-      nsds5replicabindmethod: SIMPLE
+      nsds5replicabindmethod: "{{ dirsrv_replica_bind_method }}"
       nsds5replicaroot: "{{ dirsrv_suffix }}"
       description: "Agreement between this server (supplier) and {{ dirsrv_consumer_uri }} (consumer). Managed by Ansible."
       nsds5replicatedattributelist: "{{ dirsrv_replica_attributes_list }}"
@@ -51,7 +51,7 @@
   loop:
     - { name: "nsds5replicaport", value: "{{ '389' if not dirsrv_consumer_uri|urlsplit('port') else dirsrv_consumer_uri|urlsplit('port') }}" }
     - { name: "nsds5ReplicaBindDN", value: "cn={{ dirsrv_replication_user_remote | default(dirsrv_replication_user) }},cn=config" }
-    - { name: "nsds5replicabindmethod", value: "SIMPLE" }  # TODO: SASL/PLAIN doesn't seem to be allowed?
+    - { name: "nsds5replicabindmethod", value: "{{ dirsrv_replica_bind_method }}" }
     - { name: "nsds5replicaroot", value: "{{ dirsrv_suffix }}" }
     - { name: "description", value: "Agreement between this server (supplier) and {{ dirsrv_consumer_uri }} (consumer). Managed by Ansible." }
     - { name: "nsds5replicatedattributelist", value: "{{ dirsrv_replica_attributes_list }}" }

--- a/tasks/configure_replication_user.yml
+++ b/tasks/configure_replication_user.yml
@@ -2,7 +2,11 @@
 # The supplier will bind with this account on the consumer, so the account should exist on the consumer
 - name: Add "supplier bind DN entry" to consumer
   ldap_entry:
-    params: "{{ dirsrv_ldap_auth }}"
+    server_uri: "{{ dirsrv_server_uri }}"
+    validate_certs: "{{ dirsrv_tls_certificate_trusted }}"
+    start_tls: "{{ dirsrv_starttls_early }}"
+    bind_dn: "{{ dirsrv_rootdn }}"
+    bind_pw: "{{ dirsrv_rootdn_password }}"
     dn: "cn={{ dirsrv_replication_user }},cn=config"
     objectClass:
       - top
@@ -17,7 +21,11 @@
 # Allows password change, since if entry exists, ldap_entry doesn't update attributes
 - name: Set "supplier bind DN entry" attributes
   ldap_attr:
-    params: "{{ dirsrv_ldap_auth }}"
+    server_uri: "{{ dirsrv_server_uri }}"
+    validate_certs: "{{ dirsrv_tls_certificate_trusted }}"
+    start_tls: "{{ dirsrv_starttls_early }}"
+    bind_dn: "{{ dirsrv_rootdn }}"
+    bind_pw: "{{ dirsrv_rootdn_password }}"
     dn: "cn={{ dirsrv_replication_user }},cn=config"
     name: "{{ item.name }}"
     values: "{{ item.value }}"

--- a/tasks/configure_supplier.yml
+++ b/tasks/configure_supplier.yml
@@ -1,7 +1,11 @@
 ---
 - name: Create Supplier Replica Entry
   ldap_entry:
-    params: "{{ dirsrv_ldap_auth }}"
+    server_uri: "{{ dirsrv_server_uri }}"
+    validate_certs: "{{ dirsrv_tls_certificate_trusted }}"
+    start_tls: "{{ dirsrv_starttls_early }}"
+    bind_dn: "{{ dirsrv_rootdn }}"
+    bind_pw: "{{ dirsrv_rootdn_password }}"
     dn: "cn=replica,cn=\"{{ dirsrv_suffix }}\",cn=mapping tree,cn=config"
     objectClass:
       - top
@@ -17,7 +21,11 @@
 
 - name: Configure Supplier Replica Entry
   ldap_attr:
-    params: "{{ dirsrv_ldap_auth }}"
+    server_uri: "{{ dirsrv_server_uri }}"
+    validate_certs: "{{ dirsrv_tls_certificate_trusted }}"
+    start_tls: "{{ dirsrv_starttls_early }}"
+    bind_dn: "{{ dirsrv_rootdn }}"
+    bind_pw: "{{ dirsrv_rootdn_password }}"
     dn: "cn=replica,cn=\"{{ dirsrv_suffix }}\",cn=mapping tree,cn=config"
     name: "{{ item.name }}"
     values: "{{ item.value }}"


### PR DESCRIPTION
Hi, same changes here to remove the use of _params_

Also, for me _nsds5replicabindmethod: SIMPLE_ did not work, so I added a variable (default to _PLAIN_, because it's what worked for me.